### PR TITLE
Fixed User lanuage being Menu bug

### DIFF
--- a/server.js
+++ b/server.js
@@ -510,7 +510,7 @@ async function processReportInBackground(file, latitude, longitude, description,
     // Send confirmation to user immediately after saving the query
     const confirmationPromise = sendWhatsAppMessage(
       userId,
-      `Thank you! Your ${queryTypeText} report has been submitted successfully and assigned to the ${matchingDivision.name} division. You will be notified when there are updates.`
+      `Thank you! Your ${queryTypeText} report has been submitted successfully and assigned to the ${matchingDivision.name} division. You will be notified when there are updates. Feel free to send another message in case of more reports.`
     );
     
     // Notify division officers in parallel
@@ -610,12 +610,6 @@ app.post('/webhook', express.urlencoded({ extended: true }), async (req, res) =>
       newLastOption = null;
       console.log('User session reset to language selection');
     }
-    // Special command to return to menu from any state
-    else if (userMessage && userMessage.toLowerCase() === 'menu') {
-      responseMessage = getMainMenu(userLanguage);
-      newState = 'MENU';
-      newLastOption = null;
-    }
     // Handle language selection state
     else if (currentState === 'LANGUAGE_SELECT') {
       if (userMessage === '1') {
@@ -645,6 +639,12 @@ app.post('/webhook', express.urlencoded({ extended: true }), async (req, res) =>
       // Then show the main menu
       responseMessage += '\n\n' + getMainMenu(userLanguage);
       newState = 'MENU';
+    }
+    // Special command to return to menu from any state
+    else if (userMessage && userMessage.toLowerCase() === 'menu') {
+      responseMessage = getMainMenu(userLanguage);
+      newState = 'MENU';
+      newLastOption = null;
     }
     // Handle menu state
     else if (currentState === 'MENU') {

--- a/utils/language.js
+++ b/utils/language.js
@@ -72,7 +72,7 @@ const translations = {
 REPORT_CONFIRMATION: {
   en: "Thank you! Your *{0}* report has been submitted successfully and assigned to the *{1}* division. You will be notified when there are updates.",
   hi: "धन्यवाद! आपकी *{0}* रिपोर्ट सफलतापूर्वक जमा की गई है और *{1}* डिवीजन को सौंपी गई है। अपडेट होने पर आपको सूचित किया जाएगा।",
-  mr: "धन्यवाद! आपला *{0}* अहवाल यशस्वीरित्या सबमिट केला आहे आणि *{1}* विभागाला नियुक्त केला आहे. अपडेट झाल्यावर आपल्याला सूचित केले जाईल."
+  mr: "धन्यवाद! आपला *{0}* अहवाल यशस्वीरित्या सबमिट केला आहे आणि *{1}* विभागाला नियुक्त केला आहे. अपडेट झाल्यावर आपल्याला सूचित केले जाईल. अधिक तक्रारी असल्यास दुसरा संदेश पाठवा."
 },
 REPORT_ERROR: {
   en: "We're sorry, but there was an error processing your report. Please try again later.",


### PR DESCRIPTION
BUGFIX: If the user's first message was `MENU,` the bot would ignore all the `NAME_SELECT` and `LANGUAGE_SELECT `instructions and allow the user to send anonymous requests.

Feature: Added text to the final report successful text:

EN: Feel free to send another message in case of more reports.
MR: अधिक तक्रारी असल्यास दुसरा संदेश पाठवा.
